### PR TITLE
Dynamic backend servers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,11 @@ haproxy_dependencies:
     state: latest
 haproxy_install: []
 
+# A list of groups that will be searched during dynamic backend discovery
+haproxy_backend_search: yes
+haproxy_backend_search_group: all
+haproxy_backend_search_var: haproxy_backend_member
+
 # global section
 haproxy_global_log:
   - address: /dev/log

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,3 @@
 # process, which may cause wedges in the gate later.
 bashate>=0.2 # Apache-2.0
 flake8<2.6.0,>=2.5.4 # MIT
-
-# Needed for ansible json_query filter
-jmespath

--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -84,4 +84,15 @@ backend {{ backend.name }}
 
 {% endfor %}
 
+{% if haproxy_backend_search | bool %}
+{% for _server in groups[haproxy_backend_search_group] |
+                  map('extract', hostvars, haproxy_backend_search_var) |
+                  select('defined') |
+                  map(attribute=backend.name) |
+                  select('defined') | list %}
+  server {{ _server.name }} {{ _server.listen }} {{ _server.param | default([]) | join(' ') }}
+
+{% endfor %}
+{% endif %}
+
 {% endfor %}

--- a/tests/common-tasks/docker-create.yml
+++ b/tests/common-tasks/docker-create.yml
@@ -16,6 +16,7 @@
 - name: Ensure docker-py is installed
   pip:
     name: docker-py
+  when: "inventory_hostname == ansible_play_hosts[0]"
 
 - name: Ensure docker container
   docker_container:

--- a/tests/group_vars/haproxy.yml
+++ b/tests/group_vars/haproxy.yml
@@ -1,0 +1,33 @@
+---
+# Copyright 2017, Logan Vig <logan2211@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+haproxy_frontend:
+  - name: test-front
+    description: Test frontend
+    bind:
+      - listen: 0.0.0.0:10000
+    mode: http
+    option:
+      - httplog
+    default_backend: test-back
+
+haproxy_backend:
+  - name: test-back
+    description: Test backend
+    mode: http
+    balance: roundrobin
+    option:
+      - forwardfor
+      - 'httpchk HEAD / HTTP/1.1\r\nHost:localhost\r\nUser-agent:\ HAProxy'

--- a/tests/group_vars/test_backend_servers.yml
+++ b/tests/group_vars/test_backend_servers.yml
@@ -1,0 +1,19 @@
+---
+# Copyright 2017, Logan Vig <logan2211@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+haproxy_backend_member:
+  'test-back':
+    name: "{{ inventory_hostname }}"
+    listen: "{{ ansible_host }}:1111"

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,13 +1,17 @@
 [all]
 localhost ansible_connection=local ansible_become=True
 
-[test_containers]
+[haproxy]
 haproxy1.5 physical_host=localhost haproxy_version=1.5
 haproxy1.6 physical_host=localhost haproxy_version=1.6
 haproxy1.7 physical_host=localhost haproxy_version=1.7
 
+[test_backend_servers]
+test1 ansible_host=10.0.0.1
+test2 ansible_host=10.0.0.2
+
 [docker_containers:children]
-test_containers
+haproxy
 
 [docker_containers:vars]
 ansible_connection=docker

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -16,10 +16,29 @@
 - include: test-create-containers.yml
 
 - name: Playbook for role testing
-  hosts: test_containers
+  hosts: haproxy
   roles:
     - role: "{{ rolename | basename }}"
   post_tasks:
+    - name: Install socat for testing
+      package:
+        name: socat
     - name: Check if the haproxy service is running
       command: pgrep haproxy
+      changed_when: false
+
+- name: Ensure the test dynamic servers are enabled
+  hosts: test_backend_servers
+  gather_facts: no
+  tasks:
+    - name: Ensure the endpoint is enabled
+      shell: >
+        echo "show stat {{ inventory_hostname }}" |
+        socat unix-connect:/run/haproxy/admin.sock stdio |
+        grep {{ inventory_hostname }} |
+        cut -d, -f18
+      delegate_to: "{{ item }}"
+      with_items: "{{ groups['haproxy'] }}"
+      register: haproxy_status
+      failed_when: "haproxy_status.stdout != 'no check'"
       changed_when: false


### PR DESCRIPTION
Read from hostvars to dynamically allocate hosts to a given backend.

Define haproxy_frontend, haproxy_backend as per normal in the load
balancer group_vars. Do not need to define any 'server' list on the
mariadb-back backend. Instead, define in your mariadb node group_vars:

From ex. group_vars/mariadb.yml:
```yaml
haproxy_backend_member:
  'mariadb-back':
    name: "{{ inventory_hostname }}"
    listen: "{{ ansible_host }}:3306"
    param:
      - 'check port 3306'
      - 'rise 2'
      - 'fall 2'
```

This will add a 'server' entry under the 'mariadb-back' backend for
each host in the mariadb group.