### PR TITLE
Use reloads instead of restarts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,12 @@ haproxy_backend_search: yes
 haproxy_backend_search_group: all
 haproxy_backend_search_var: haproxy_backend_member
 
+# Some haproxy features will not work well with reload and require a hard
+# restart instead. By default we will use the reloaded state and users can
+# change the handler to perform a hard-restart when configuration change
+# occurs by setting this to "restarted"
+haproxy_reload_mode: reloaded
+
 # global section
 haproxy_global_log:
   - address: /dev/log

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 # handlers file for haproxy
 ---
-- name: restart haproxy
+- name: reload haproxy
   service:
     name: haproxy
-    state: restarted
+    state: "{{ haproxy_reload_mode }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,7 +60,7 @@
     group: "{{ item.group | default('root') }}"
     mode: "{{ item.mode | default('0640') }}"
   with_items: "{{ haproxy_ssl_map }}"
-  notify: restart haproxy
+  notify: reload haproxy
   tags:
     - configuration
     - haproxy
@@ -75,7 +75,7 @@
     group: root
     mode: 0640
     validate: 'haproxy -f %s -c'
-  notify: restart haproxy
+  notify: reload haproxy
   tags:
     - configuration
     - haproxy


### PR DESCRIPTION
In cases of configuration change, haproxy init scripts support a
HUP reload instead of a full restart, allowing existing sessions
to end gracefully without a forceful restart.