### PR TITLE
Use url to load apt key instead of hkp

### DIFF
--- a/tasks/pre_install_apt.yml
+++ b/tasks/pre_install_apt.yml
@@ -15,7 +15,8 @@
 
 - name: Add an apt key by id from a keyserver
   apt_key:
-    keyserver: "{{ haproxy_ppa_keyserver }}"
+    keyserver: "{{ haproxy_ppa_keyserver | default(omit) }}"
+    url: "{{ haproxy_ppa_keyurl | default(omit) }}"
     id: "{{ haproxy_ppa_key }}"
   when:
     - haproxy_ppa_enabled | bool

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -19,7 +19,7 @@ cache_timeout: 600
 _haproxy_repo: "http://ppa.launchpad.net/vbernat/haproxy-{{ haproxy_ppa_version }}/ubuntu"
 haproxy_repo_full: "deb {{ haproxy_repo }} {{ ansible_distribution_release }} main"
 haproxy_repo_filename: haproxy
-haproxy_ppa_keyserver: keyserver.ubuntu.com
+haproxy_ppa_keyurl: "https://keyserver.ubuntu.com/pks/lookup?op=get&search={{ haproxy_ppa_key }}"
 haproxy_ppa_key: '0x1C61B9CD'
 
 haproxy_distro_packages:


### PR DESCRIPTION
The keyserver parameter for the apt_key module does not use proxy
environment settings. Instead, we need to use the apt_key 'url' param.